### PR TITLE
Fix type module

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Or if you are using native ES Modules:
 
 ```html
 <script type="module">
-  import placekit from 'https://cdn.jsdelivr.net/npm/@placekit/client-js@1.0.0/dist/placekit.esm.js';
+  import placekit from 'https://cdn.jsdelivr.net/npm/@placekit/client-js@1.0.0-alpha.2/dist/placekit.esm.js';
   const pk = placekit(/* ... */);
   // ...
 </script>

--- a/examples/headlessui-react/package.json
+++ b/examples/headlessui-react/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.4",
     "@heroicons/react": "^2.0.13",
-    "@placekit/client-js": "^1.0.0-alpha.0",
+    "@placekit/client-js": "^1.0.0-alpha.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/examples/headlessui-vue/package.json
+++ b/examples/headlessui-vue/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "@headlessui/vue": "^1.7.4",
     "@heroicons/vue": "^2.0.13",
-    "@placekit/client-js": "^1.0.0-alpha.0"
+    "@placekit/client-js": "^1.0.0-alpha2"
   }
 }

--- a/examples/node-express/package.json
+++ b/examples/node-express/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@placekit/client-js": "^1.0.0-alpha.0",
+    "@placekit/client-js": "^1.0.0-alpha.2",
     "dotenv": "^16.0.1",
     "express": "^4.18.1"
   }

--- a/examples/node-typescript/package.json
+++ b/examples/node-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@placekit/client-js": "^1.0.0-alpha.0",
+    "@placekit/client-js": "^1.0.0-alpha.2",
     "dotenv": "^16.0.1"
   },
   "devDependencies": {

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@placekit/client-js": "^1.0.0-alpha.0",
+    "@placekit/client-js": "^1.0.0-alpha.2",
     "dotenv": "^16.0.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/client-js",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/client-js",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^23.0.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "bugs": {
     "url": "https://github.com/placekit/client-js/issues"
   },
-  "type": "module",
   "types": "./dist/placekit.d.ts",
   "module": "./dist/placekit.esm.js",
   "main": "./dist/placekit.cjs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/client-js",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit JavaScript client",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,10 @@
-import path from 'path';
+const path = require('path');
 
-import commonjs from '@rollup/plugin-commonjs';
-import cleanup from 'rollup-plugin-cleanup';
-import copy from 'rollup-plugin-copy';
+const commonjs = require('@rollup/plugin-commonjs');
+const cleanup = require('rollup-plugin-cleanup');
+const copy = require('rollup-plugin-copy');
 
-import pkg from './package.json' assert { type: "json" };
+const pkg = require('./package.json');
 const banner = [
   `/*! ${pkg.name} v${pkg.version}`,
   '© placekit.io',
@@ -12,7 +12,7 @@ const banner = [
   `${pkg.homepage} */`,
 ].join(' | ');
 
-export default {
+module.exports = {
   input: 'src/index.js',
   output: [
     {


### PR DESCRIPTION
- Remove `"type": "module"` causing import error in (at least) Next.js.
- Update `rollup.config.js` to use `require` instead of `import` to prevent build error.