### PR TITLE
reverse and countries

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | `maxResults` | `integer?` | `5` | Number of results per page. |
 | `language` | `string?` | `undefined` | Language of the results, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. Defaults to the country's language if available. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
-| `countries` | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the [supported list of countries](#supported-countries). |
+| [`countries`](#%EF%B8%8F-countries-option-is-required) | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the [supported list of countries](#supported-countries). |
 | [`countryByIP`](#countryByIP-option) | `boolean?` | `undefined` | Use IP to find user's country (turned off). |
 | `forwardIP` | `string?` | `undefined` | Set `x-forwarded-for` header to forward the provided IP for back-end usages (otherwise it'll use the server IP). |
 | `coordinates` | `string?` | `undefined` | Coordinates to search around. Automatically set when calling [`pk.requestGeolocation()`](#pkrequestGeolocation). |
@@ -211,7 +211,7 @@ The `countries` option is **required** at search time, but we like to keep it op
 - with `pk.configure()`,
 - or at search time with `pk.search()`.
 
-If `countries` is invalid, you'll get a `422` error.
+If `countries` is missing or invalid, you'll get a `422` error.
 
 #### Supported countries
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
 | `countries` | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the supported list of countries. |
 | `countryByIP` | `boolean?` | `undefined` | Use IP to find user's country (turned off). |
-| `overrideIP` | `string?` | `undefined` | Set `x-forwarded-for` header to override IP when `countryByIP` is `true`. |
+| `forwardIP` | `string?` | `undefined` | Set `x-forwarded-for` header to forward IP for back-end usage (otherwise it'll use the server's IP). |
 | `coordinates` | `string?` | `undefined` | Coordinates to search around. Automatically set when calling [`pk.requestGeolocation()`](#pkrequestGeolocation). |
 
 #### ⚠️ Important notes about countries
@@ -208,7 +208,6 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 - Supported countries are `be`, `ca`, `ch`, `de`, `es`, `fr`, `gb`, `it`, `nl`, `pt`, `us`.
 - For use-cases where you don't know which country users will search in beforehands, set `countryByIP` to `true`.
 - If `countryByIP` is set to `true`, the option `countries` will be used as a fallback if the user's country is not supported.
-- Careful that if the search is made server-side, the IP will be the one of the server. Use `overrideIP` option to forward user's IP to PlaceKit API.
 
 ### `pk.configure()`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
   <a href="#-quick-start">Quick start</a> • 
   <a href="#-reference">Reference</a> • 
   <a href="./examples">Examples</a> • 
-  <a href="https://placekit.io/developers">Documentation</a> • 
   <a href="#%EF%B8%8F-license">License</a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `maxResults` | `integer?` | `5` | Number of results per page. |
-| `language` | `string?` | `undefined` | Language of the results, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. Defaults to the country's language. |
+| `language` | `string?` | `undefined` | Language of the results, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. Defaults to the country's language if available. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
 | `countries` | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the supported list of countries. |
 | `countryByIP` | `boolean?` | `undefined` | Use IP to find user's country (turned of). |

--- a/README.md
+++ b/README.md
@@ -197,17 +197,29 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | `maxResults` | `integer?` | `5` | Number of results per page. |
 | `language` | `string?` | `undefined` | Language of the results, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. Defaults to the country's language if available. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
-| `countries` | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the supported list of countries. |
-| `countryByIP` | `boolean?` | `undefined` | Use IP to find user's country (turned off). |
-| `forwardIP` | `string?` | `undefined` | Set `x-forwarded-for` header to forward IP for back-end usage (otherwise it'll use the server's IP). |
+| `countries` | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the [supported list of countries](#supported-countries). |
+| [`countryByIP`](#countryByIP-option) | `boolean?` | `undefined` | Use IP to find user's country (turned off). |
+| `forwardIP` | `string?` | `undefined` | Set `x-forwarded-for` header to forward the provided IP for back-end usages (otherwise it'll use the server IP). |
 | `coordinates` | `string?` | `undefined` | Coordinates to search around. Automatically set when calling [`pk.requestGeolocation()`](#pkrequestGeolocation). |
 
 #### ⚠️ Important notes about countries
 
-- The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it (either when instanciating with `placekit()`, with `pk.configure()`, or at search time with `pk.search()`). If `countries` is invalid, you'll get a `422` error.
-- Supported countries are `be`, `ca`, `ch`, `de`, `es`, `fr`, `gb`, `it`, `nl`, `pt`, `us`.
-- For use-cases where you don't know which country users will search in beforehands, set `countryByIP` to `true`.
-- If `countryByIP` is set to `true`, the option `countries` will be used as a fallback if the user's country is not supported.
+The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it (either when instanciating with `placekit()`, with `pk.configure()`, or at search time with `pk.search()`). If `countries` is invalid, you'll get a `422` error.
+
+#### Supported countries
+
+Supported countries are `be`, `ca`, `ch`, `de`, `es`, `fr`, `gb`, `it`, `nl`, `pt`, `us`.
+
+#### `countryByIP` option
+
+Set `countryByIP` to `true` when you don't know which country users will search addresses in. In that case, the option `countries` will be used as a fallback if the user's country is not supported:
+
+```js
+pk.search('123 ave', {
+  countryByIP: true, // use user's country, based on their IP
+  countries: ['fr', 'be'], // returning results from France and Belgium if user's country is not supported
+});
+```
 
 ### `pk.configure()`
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ const placekit = require('@placekit/client-js');
 import placekit from '@placekit/client-js';
 
 const pk = placekit('<your-api-key>', {
+  countries: ['fr'],
   //...
 });
 

--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ pk.search('Paris', {
 ### `pk.reverse()`
 
 Performs a reverse geocoding search and returns a Promise, which response is a list of results alongside some request metadata.
-The options passed as second parameter override the global parameters only for the current query.
+The options passed as first parameter override the global parameters only for the current query.
 Any `coordinates` previously set as option would be overriden by the coordinates passed as first argument.
 
 ```js
-pk.reverse('48.871086,2.3036339', {
+pk.reverse({
+  coordinates: '48.871086,2.3036339',
   countries: ['fr'],
   maxResults: 5,
 }).then((res) => {
@@ -164,22 +165,23 @@ pk.reverse('48.871086,2.3036339', {
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `coordinates` | `string` | `"lat,lng"` formatted coordinates. |
 | `opts` | `key-value mapping` (optional) | Search-specific parameters (see [options](#pkoptions)) |
 
-**Note:** when calling `pk.reverse()`, the API automatically sets `countryByIP` to `true`. Explicitely set it to `false` to turn it off.
-
-So calling `pk.reverse()` is the same as calling `pk.search` with an empty query, coordinates and `countryByIP: true`:
+**Notes:**
+- If you omit `options.coordinates`, it'll use `coordinates` from global parameters set when instanciating with `placekit()` or with `pk.configure()`.
+- If no coordinates are found when calling `pk.reverse()`, then it'll use the user's IP approximate coordinates but relevance will be less accurate.
+- When calling `pk.reverse()`, the API automatically sets `countryByIP` to `true`. Explicitely set it to `false` to turn it off.
+- Calling `pk.reverse()` is the same as calling `pk.search` with an empty query and `countryByIP: true`:
 
 ```js
-// same output as `pk.reverse()`
+pk.reverse({
+  countries: ['fr'],
+});
+
+// is the same as:
 pk.search('', {
-  coordinates: '48.871086,2.3036339',
   countryByIP: true,
   countries: ['fr'],
-  maxResults: 5,
-}).then((res) => {
-  console.log(res.results);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 
 #### ⚠️ Important notes about countries
 
-- The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it (either when instanciating with `placekit()`, with `pk.configure()`, or at search time with `pk.search()`).
+- The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it (either when instanciating with `placekit()`, with `pk.configure()`, or at search time with `pk.search()`). If `countries` is invalid, you'll get a `422` error.
 - For use-cases where you don't know which country users will search in beforehands, set `countryByIP` to `true`.
 - If `countryByIP` is set to `true`, the option `countries` will be used as a fallback if the user's country is not supported.
 - Careful that it the search is made server-side, the IP will be the one of the server. Use `overrideIP` option to forward user's IP to PlaceKit API.

--- a/README.md
+++ b/README.md
@@ -202,9 +202,14 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | `forwardIP` | `string?` | `undefined` | Set `x-forwarded-for` header to forward the provided IP for back-end usages (otherwise it'll use the server IP). |
 | `coordinates` | `string?` | `undefined` | Coordinates to search around. Automatically set when calling [`pk.requestGeolocation()`](#pkrequestGeolocation). |
 
-#### ⚠️ Important notes about countries
+#### ⚠️ `countries` option is required
 
-The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it (either when instanciating with `placekit()`, with `pk.configure()`, or at search time with `pk.search()`). If `countries` is invalid, you'll get a `422` error.
+The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it: 
+- either when instanciating with `placekit()`,
+- with `pk.configure()`,
+- or at search time with `pk.search()`.
+
+If `countries` is invalid, you'll get a `422` error.
 
 #### Supported countries
 

--- a/README.md
+++ b/README.md
@@ -159,10 +159,17 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | `maxResults` | `integer?` | `5` | Number of results per page. |
 | `language` | `string?` | `undefined` | Language of the results, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
-| `countries` | `string[]?` | `undefined` | Limit results to given countries. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes. |
+| `countries` | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the supported list of countries. |
+| `countryByIP` | `boolean?` | `undefined` | Use IP to find user's country (turned of). |
+| `overrideIP` | `string?` | `undefined` | Set `x-forwarded-for` header to override IP when `countryByIP` is `true`. |
 | `coordinates` | `string?` | `undefined` | Coordinates to search around. Automatically set when calling [`pk.requestGeolocation()`](#pkrequestGeolocation). |
 
-**Important**: the `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it.
+#### ⚠️ Important notes about countries
+
+- The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it (either when instanciating with `placekit()`, with `pk.configure()`, or at search time with `pk.search()`).
+- For use-cases where you don't know which country users will search in beforehands, set `countryByIP` to `true`.
+- If `countryByIP` is set to `true`, the option `countries` will be used as a fallback if the user's country is not supported.
+- Careful that it the search is made server-side, the IP will be the one of the server. Use `overrideIP` option to forward user's IP to PlaceKit API.
 
 ### `pk.configure()`
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Or if you are using native ES Modules:
 
 - [`placekit()`](#placekit)
 - [`pk.search()`](#pksearch)
+- [`pk.reverse()`](#pkreverse)
 - [`pk.options`](#pkoptions)
 - [`pk.configure()`](#pkconfigure)
 - [`pk.requestGeolocation()`](#pkrequestGeolocation)
@@ -116,6 +117,7 @@ PlaceKit initialization function returns a PlaceKit client, named `pk` in all ex
 
 ```js
 const pk = placekit('<your-api-key>', {
+  countries: ['fr'],
   language: 'en',
   maxResults: 10,
 });
@@ -133,8 +135,8 @@ The options passed as second parameter override the global parameters only for t
 
 ```js
 pk.search('Paris', {
-  maxResults: 5, 
   countries: ['fr'],
+  maxResults: 5, 
 }).then((res) => {
   console.log(res.results);
 });
@@ -144,6 +146,42 @@ pk.search('Paris', {
 | --- | --- | --- |
 | `query` | `string` | Search terms |
 | `opts` | `key-value mapping` (optional) | Search-specific parameters (see [options](#pkoptions)) |
+
+### `pk.reverse()`
+
+Performs a reverse geocoding search and returns a Promise, which response is a list of results alongside some request metadata.
+The options passed as second parameter override the global parameters only for the current query.
+Any `coordinates` previously set as option would be overriden by the coordinates passed as first argument.
+
+```js
+pk.reverse('48.871086,2.3036339', {
+  countries: ['fr'],
+  maxResults: 5,
+}).then((res) => {
+  console.log(res.results);
+});
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `coordinates` | `string` | `"lat,lng"` formatted coordinates. |
+| `opts` | `key-value mapping` (optional) | Search-specific parameters (see [options](#pkoptions)) |
+
+**Note:** when calling `pk.reverse()`, the API automatically sets `countryByIP` to `true`. Explicitely set it to `false` to turn it off.
+
+So calling `pk.reverse()` is the same as calling `pk.search` with an empty query, coordinates and `countryByIP: true`:
+
+```js
+// same output as `pk.reverse()`
+pk.search('', {
+  coordinates: '48.871086,2.3036339',
+  countryByIP: true,
+  countries: ['fr'],
+  maxResults: 5,
+}).then((res) => {
+  console.log(res.results);
+});
+```
 
 ### `pk.options`
 
@@ -157,7 +195,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `maxResults` | `integer?` | `5` | Number of results per page. |
-| `language` | `string?` | `undefined` | Language of the results, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. |
+| `language` | `string?` | `undefined` | Language of the results, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. Defaults to the country's language. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
 | `countries` | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the supported list of countries. |
 | `countryByIP` | `boolean?` | `undefined` | Use IP to find user's country (turned of). |
@@ -167,6 +205,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 #### ⚠️ Important notes about countries
 
 - The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it (either when instanciating with `placekit()`, with `pk.configure()`, or at search time with `pk.search()`). If `countries` is invalid, you'll get a `422` error.
+- Supported countries are `be`, `ca`, `ch`, `de`, `es`, `fr`, `gb`, `it`, `nl`, `pt`, `us`.
 - For use-cases where you don't know which country users will search in beforehands, set `countryByIP` to `true`.
 - If `countryByIP` is set to `true`, the option `countries` will be used as a fallback if the user's country is not supported.
 - Careful that it the search is made server-side, the IP will be the one of the server. Use `overrideIP` option to forward user's IP to PlaceKit API.

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | `language` | `string?` | `undefined` | Language of the results, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. Defaults to the country's language if available. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
 | `countries` | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes in the supported list of countries. |
-| `countryByIP` | `boolean?` | `undefined` | Use IP to find user's country (turned of). |
+| `countryByIP` | `boolean?` | `undefined` | Use IP to find user's country (turned off). |
 | `overrideIP` | `string?` | `undefined` | Set `x-forwarded-for` header to override IP when `countryByIP` is `true`. |
 | `coordinates` | `string?` | `undefined` | Coordinates to search around. Automatically set when calling [`pk.requestGeolocation()`](#pkrequestGeolocation). |
 
@@ -208,7 +208,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 - Supported countries are `be`, `ca`, `ch`, `de`, `es`, `fr`, `gb`, `it`, `nl`, `pt`, `us`.
 - For use-cases where you don't know which country users will search in beforehands, set `countryByIP` to `true`.
 - If `countryByIP` is set to `true`, the option `countries` will be used as a fallback if the user's country is not supported.
-- Careful that it the search is made server-side, the IP will be the one of the server. Use `overrideIP` option to forward user's IP to PlaceKit API.
+- Careful that if the search is made server-side, the IP will be the one of the server. Use `overrideIP` option to forward user's IP to PlaceKit API.
 
 ### `pk.configure()`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/client-js",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/client-js",
-      "version": "1.0.0-alpha.2",
+      "version": "1.0.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^23.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/client-js",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit JavaScript client",
   "license": "MIT",
@@ -13,13 +13,13 @@
     "url": "https://github.com/placekit/client-js/issues"
   },
   "types": "./dist/placekit.d.ts",
-  "module": "./dist/placekit.esm.js",
+  "module": "./dist/placekit.esm.mjs",
   "main": "./dist/placekit.cjs.js",
   "browser": "./dist/placekit.umd.js",
   "exports": {
     ".": {
       "require": "./dist/placekit.cjs.js",
-      "import": "./dist/placekit.esm.js"
+      "import": "./dist/placekit.esm.mjs"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "browser": "./dist/placekit.umd.js",
   "exports": {
     ".": {
+      "types": "./dist/placekit.d.ts",
       "require": "./dist/placekit.cjs.js",
       "import": "./dist/placekit.esm.mjs"
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,12 +29,16 @@ type PKType =
   "-townhall" | 
   "-tourism";
 
+type PKCountry = "be" | "ca" | "ch" | "de" | "es" | "fr" | "gb" | "it" | "nl" | "pt" | "us";
+
 export type PKOptions = Partial<{
   timeout?: number;
   maxResults?: number;
   language?: string;
   types?: PKType[];
-  countries?: string[];
+  countries?: PKCountry[];
+  countryByIP?: boolean;
+  overrideIP?: string;
   coordinates?: string;
 }>;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,7 +39,7 @@ export type PKOptions = Partial<{
   types?: PKType[];
   countries?: PKCountry[];
   countryByIP?: boolean;
-  overrideIP?: string;
+  forwardIP?: string;
   coordinates?: string;
 }>;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,7 @@ declare function PlaceKit(apiKey?: string, opts?: PKOptions): PKClient;
 
 export interface PKClient {
   search(query: string, opts?: PKOptions): Promise<PKSearchResponse>;
-  reverse(coordinates: string, opts?: PKOptions): Promise<PKSearchResponse>;
+  reverse(opts?: PKOptions): Promise<PKSearchResponse>;
   readonly options: PKOptions;
   configure(opts?: PKOptions): void;
   readonly hasGeolocation: boolean;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ declare function PlaceKit(apiKey?: string, opts?: PKOptions): PKClient;
 
 export interface PKClient {
   search(query: string, opts?: PKOptions): Promise<PKSearchResponse>;
+  reverse(coordinates: string, opts?: PKOptions): Promise<PKSearchResponse>;
   readonly options: PKOptions;
   configure(opts?: PKOptions): void;
   readonly hasGeolocation: boolean;
@@ -34,7 +35,7 @@ type PKCountry = "be" | "ca" | "ch" | "de" | "es" | "fr" | "gb" | "it" | "nl" | 
 export type PKOptions = Partial<{
   timeout?: number;
   maxResults?: number;
-  language?: string;
+  language?: "fr" | "en";
   types?: PKType[];
   countries?: PKCountry[];
   countryByIP?: boolean;
@@ -62,5 +63,4 @@ export type PKSearchResponse = {
   resultsCount: number;
   maxResults: number;
   query: string;
-  params: string;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@
  * @prop {string[]} [types] Results type
  * @prop {string} [language] Results language (ISO 639-1)
  * @prop {boolean} [countryByIP] Get country from IP
- * @prop {boolean} [overrideIP] Set `x-forwarded-for` header to override IP when `countryByIP` is `true`.
+ * @prop {boolean} [forwardIP] Set `x-forwarded-for` header to override IP when `countryByIP` is `true`.
  * @prop {string[]} [countries] Countries to search in, or fallback to if `countryByIP` is true (ISO 639-1)
  * @prop {string} [coordinates] Coordinates search starts around
  */
@@ -76,7 +76,7 @@ module.exports = (apiKey, options = {}) => {
    * @return {Promise<SearchResponse>}
    */
   const request = (method = 'POST', resource = '', opts = {}) => {
-    const { timeout, overrideIP, ...params } = opts;
+    const { timeout, forwardIP, ...params } = opts;
     const controller = new AbortController();
     const id = typeof timeout !== 'undefined' ? setTimeout(() => controller.abort(), timeout) : undefined;
     const url = [
@@ -87,8 +87,8 @@ module.exports = (apiKey, options = {}) => {
       'Content-Type': 'application/json; charset=UTF-8',
       'x-placekit-api-key': apiKey,
     };
-    if (params.countryByIP && overrideIP) {
-      headers['x-forwarded-for'] = overrideIP;
+    if (params.countryByIP && forwardIP) {
+      headers['x-forwarded-for'] = forwardIP;
     }
     return fetch(url, {
       method,

--- a/src/index.js
+++ b/src/index.js
@@ -148,21 +148,16 @@ module.exports = (apiKey, options = {}) => {
   /**
    * PlaceKit reverse geocoding
    * @memberof client
-   * @param {string} coordinates Coordinates "lat,lng"
    * @param {Options} [opts] Override global parameters
    * @return {Promise<SearchResponse>}
    */
-  client.reverse = (coordinates, opts = {}) => {
-    if (!['string', 'undefined'].includes(typeof coordinates)) {
-      throw Error('PlaceKit: `coordinates` parameter is invalid, expected a string.');
-    }
+  client.reverse = (opts = {}) => {
     if (!['object', 'undefined'].includes(typeof opts) || Array.isArray(opts) || opts === null) {
       throw Error('PlaceKit: `opts` parameter is invalid, expected an object.');
     }
     const params = {
       ...globalParams,
       ...opts,
-      coordinates,
     };
     return request('POST', 'reverse', params);
   };

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ module.exports = (apiKey, options = {}) => {
       'Content-Type': 'application/json; charset=UTF-8',
       'x-placekit-api-key': apiKey,
     };
-    if (params.countryByIP && forwardIP) {
+    if (forwardIP) {
       headers['x-forwarded-for'] = forwardIP;
     }
     return fetch(url, {

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@
  * @prop {number} resultsCount Actual number of results
  * @prop {number} maxResults Max number of results
  * @prop {string} query Search query
- * @prop {string} params Search parameters (query string)
  */
 
 /**
@@ -144,6 +143,28 @@ module.exports = (apiKey, options = {}) => {
       query,
     };
     return request('POST', 'search', params);
+  };
+
+  /**
+   * PlaceKit reverse geocoding
+   * @memberof client
+   * @param {string} coordinates Coordinates "lat,lng"
+   * @param {Options} [opts] Override global parameters
+   * @return {Promise<SearchResponse>}
+   */
+  client.reverse = (coordinates, opts = {}) => {
+    if (!['string', 'undefined'].includes(typeof coordinates)) {
+      throw Error('PlaceKit: `coordinates` parameter is invalid, expected a string.');
+    }
+    if (!['object', 'undefined'].includes(typeof opts) || Array.isArray(opts) || opts === null) {
+      throw Error('PlaceKit: `opts` parameter is invalid, expected an object.');
+    }
+    const params = {
+      ...globalParams,
+      ...opts,
+      coordinates,
+    };
+    return request('POST', 'reverse', params);
   };
 
   /**

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -135,31 +135,7 @@ describe('Search', () => {
     expect(res.results).toHaveLength(0);
   });
 
-  it('ignores forwardIP if countryByIP is off', async () => {
-    fetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => ({ results: [] })
-    });
-    const pk = placekit('your-api-key');
-    const res = await pk.search('', {
-      forwardIP: '0.0.0.0',
-    });
-    expect(fetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        method: 'POST',
-        signal: expect.anything(),
-        headers: {
-          'Content-Type': 'application/json; charset=UTF-8',
-          'x-placekit-api-key': 'your-api-key',
-        },
-      })
-    );
-    expect(res.results).toHaveLength(0);
-  });
-
-  it('sets `x-forwarded-for` header if forwardIP is set', async () => {
+  it('sets `x-forwarded-for` header from forwardIP option', async () => {
     fetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -246,11 +222,6 @@ describe('Reverse', () => {
     expect(() => {
       const pk = placekit('your-api-key');
       pk.reverse(null);
-    }).toThrow(/coordinates/i);
-
-    expect(() => {
-      const pk = placekit('your-api-key');
-      pk.reverse('', null);
     }).toThrow(/opts/i);
   });
 
@@ -261,7 +232,9 @@ describe('Reverse', () => {
       json: () => ({ results: [] })
     });
     const pk = placekit('your-api-key');
-    const res = await pk.reverse('0,0');
+    const res = await pk.reverse({
+      coordinates: '0,0',
+    });
     expect(fetch).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
@@ -285,7 +258,7 @@ describe('Reverse', () => {
     const pk = placekit('your-api-key', {
       coordinates: '1,1',
     });
-    const res = await pk.reverse('0,0', {
+    const res = await pk.reverse({
       coordinates: '2,2',
     });
     expect(fetch).toHaveBeenCalledWith(
@@ -297,7 +270,7 @@ describe('Reverse', () => {
           'Content-Type': 'application/json; charset=UTF-8',
           'x-placekit-api-key': 'your-api-key',
         },
-        body: expect.stringMatching("\"coordinates\":\"0,0\""),
+        body: expect.stringMatching("\"coordinates\":\"2,2\""),
       })
     );
     expect(res.results).toHaveLength(0);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -240,3 +240,39 @@ describe('Search', () => {
     });
   });
 });
+
+describe('Reverse', () => {
+  it('throws when args are invalid', () => {
+    expect(() => {
+      const pk = placekit('your-api-key');
+      pk.reverse(null);
+    }).toThrow(/coordinates/i);
+
+    expect(() => {
+      const pk = placekit('your-api-key');
+      pk.reverse('', null);
+    }).toThrow(/opts/i);
+  });
+
+  it('sends proper request', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => ({ results: [] })
+    });
+    const pk = placekit('your-api-key');
+    const res = await pk.reverse('0,0');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.anything(),
+        headers: {
+          'Content-Type': 'application/json; charset=UTF-8',
+          'x-placekit-api-key': 'your-api-key',
+        },
+      })
+    );
+    expect(res.results).toHaveLength(0);
+  });
+});

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -135,7 +135,7 @@ describe('Search', () => {
     expect(res.results).toHaveLength(0);
   });
 
-  it('ignores overrideIP if countryByIP is off', async () => {
+  it('ignores forwardIP if countryByIP is off', async () => {
     fetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -143,7 +143,7 @@ describe('Search', () => {
     });
     const pk = placekit('your-api-key');
     const res = await pk.search('', {
-      overrideIP: '0.0.0.0',
+      forwardIP: '0.0.0.0',
     });
     expect(fetch).toHaveBeenCalledWith(
       expect.any(String),
@@ -159,7 +159,7 @@ describe('Search', () => {
     expect(res.results).toHaveLength(0);
   });
 
-  it('sets `x-forwarded-for` header if overrideIP is set', async () => {
+  it('sets `x-forwarded-for` header if forwardIP is set', async () => {
     fetch.mockResolvedValue({
       ok: true,
       status: 200,
@@ -167,7 +167,7 @@ describe('Search', () => {
     });
     const pk = placekit('your-api-key');
     const res = await pk.search('', {
-      overrideIP: '0.0.0.0',
+      forwardIP: '0.0.0.0',
       countryByIP: true,
     });
     expect(fetch).toHaveBeenCalledWith(

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -275,4 +275,31 @@ describe('Reverse', () => {
     );
     expect(res.results).toHaveLength(0);
   });
+
+  it('overrides previously set coordinates', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => ({ results: [] })
+    });
+    const pk = placekit('your-api-key', {
+      coordinates: '1,1',
+    });
+    const res = await pk.reverse('0,0', {
+      coordinates: '2,2',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.anything(),
+        headers: {
+          'Content-Type': 'application/json; charset=UTF-8',
+          'x-placekit-api-key': 'your-api-key',
+        },
+        body: expect.stringMatching("\"coordinates\":\"0,0\""),
+      })
+    );
+    expect(res.results).toHaveLength(0);
+  });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -135,6 +135,56 @@ describe('Search', () => {
     expect(res.results).toHaveLength(0);
   });
 
+  it('ignores overrideIP if countryByIP is off', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => ({ results: [] })
+    });
+    const pk = placekit('your-api-key');
+    const res = await pk.search('', {
+      overrideIP: '0.0.0.0',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.anything(),
+        headers: {
+          'Content-Type': 'application/json; charset=UTF-8',
+          'x-placekit-api-key': 'your-api-key',
+        },
+      })
+    );
+    expect(res.results).toHaveLength(0);
+  });
+
+  it('sets `x-forwarded-for` header if overrideIP is set', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => ({ results: [] })
+    });
+    const pk = placekit('your-api-key');
+    const res = await pk.search('', {
+      overrideIP: '0.0.0.0',
+      countryByIP: true,
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: 'POST',
+        signal: expect.anything(),
+        headers: {
+          'Content-Type': 'application/json; charset=UTF-8',
+          'x-placekit-api-key': 'your-api-key',
+          'x-forwarded-for': '0.0.0.0',
+        },
+      })
+    );
+    expect(res.results).toHaveLength(0);
+  });
+
   it('retries with next host on timeout', async () => {
     fetch.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
- [x] Fix ESM export by replacing `js` extension with `mjs`.
- [x] Limit `countries` to supported countries in types.
- [x] Add `countryByIP` param.
- [x] Add `overrideIP` option to set `x-forwarded-for`.
- [x] Add reverse endpoint.
- [x] Update doc.