### PR TITLE
Clean up typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `maxResults` | `integer?` | `5` | Number of results per page. |
-| `language` | `string?` | `undefined` | Preferred language for the results<sup>[(1)](#ft1)</sup>, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. Defaults to the country's language. |
+| `language` | `string?` | `undefined` | Preferred language for the results<sup>[(1)](#ft1)</sup>, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. By default the results are displayed in their country's language. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
 | [`countries`](#%EF%B8%8F-countries-option-is-required) | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes<sup>[(1)](#ft1)</sup>. |
 | [`countryByIP`](#countryByIP-option) | `boolean?` | `undefined` | Use IP to find user's country (turned off). |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/client-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/client-js",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/client-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit JavaScript client",
   "license": "MIT",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,27 +13,27 @@ export interface PKClient {
 }
 
 type PKType = 
-  "street" | 
-  "city" | 
-  "country" | 
-  "airport" | 
-  "bus" | 
-  "train" | 
-  "townhall" | 
-  "tourism" | 
-  "-street" | 
-  "-city" | 
-  "-country" | 
-  "-airport" | 
-  "-bus" | 
-  "-train" | 
-  "-townhall" | 
-  "-tourism";
+  "airport" |
+  "bus" |
+  "city" |
+  "country" |
+  "street" |
+  "tourism" |
+  "townhall" |
+  "train" |
+  "-airport" |
+  "-bus" |
+  "-city" |
+  "-country" |
+  "-street" |
+  "-tourism" |
+  "-townhall" |
+  "-train";
 
 export type PKOptions = Partial<{
   timeout?: number;
   maxResults?: number;
-  language?: "fr" | "en";
+  language?: string;
   types?: PKType[];
   countries?: string[];
   countryByIP?: boolean;
@@ -42,17 +42,18 @@ export type PKOptions = Partial<{
 }>;
 
 export type PKResult = {
-  name: string,
-  city: string,
-  county: string,
-  administrative: string,
-  country: string,
+  name: string;
+  city: string;
+  county: string;
+  administrative: string;
+  country: string;
   countrycode: string;
-  lat: number,
-  lng: number,
-  type: string,
-  zipcode: string[],
-  population: number,
+  coordinates: string;
+  lat?: number; // deprecated
+  lng?: number; // deprecated
+  type: string;
+  zipcode: string[];
+  population: number;
   highlight: string;
 };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,7 +48,7 @@ export type PKResult = {
   administrative: string;
   country: string;
   countrycode: string;
-  coordinates: string;
+  coordinates: string; // "lat,lng"
   lat?: number; // deprecated
   lng?: number; // deprecated
   type: string;

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@
  * @prop {string} administrative
  * @prop {string} country
  * @prop {string} countrycode
- * @prop {string} coordinates
+ * @prop {string} coordinates // "lat,lng"
  * @prop {number} [lat] // deprecated
  * @prop {number} [lng] // deprecated
  * @prop {string} type

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@
  * @prop {string} [language] Results language (ISO 639-1)
  * @prop {boolean} [countryByIP] Get country from IP
  * @prop {boolean} [forwardIP] Set `x-forwarded-for` header to override IP when `countryByIP` is `true`.
- * @prop {string[]} [countries] Countries to search in, or fallback to if `countryByIP` is true (ISO 639-1)
+ * @prop {string[]} [countries] Countries to search in, or fallback to if `countryByIP` is true (ISO_3166-1_alpha-2)
  * @prop {string} [coordinates] Coordinates search starts around
  */
 
@@ -20,8 +20,9 @@
  * @prop {string} administrative
  * @prop {string} country
  * @prop {string} countrycode
- * @prop {number} lat
- * @prop {number} lng
+ * @prop {string} coordinates
+ * @prop {number} [lat] // deprecated
+ * @prop {number} [lng] // deprecated
  * @prop {string} type
  * @prop {string[]} zipcode
  * @prop {number} population
@@ -63,7 +64,7 @@ module.exports = (apiKey, options = {}) => {
     maxResults: 5,
   };
 
-  // get default language from browser settings
+  // Set default language from browser settings
   if (typeof window !== 'undefined' && navigator.language) {
     globalParams.language = navigator.language.slice(0, 2);
   }
@@ -209,7 +210,7 @@ module.exports = (apiKey, options = {}) => {
       navigator.geolocation.getCurrentPosition(
         (pos) => {
           hasGeolocation = true;
-          globalParams.coordinates = `${pos.coords.latitude}, ${pos.coords.longitude}`;
+          globalParams.coordinates = `${pos.coords.latitude},${pos.coords.longitude}`;
           resolve(pos);
         },
         (err) => {


### PR DESCRIPTION
- Sort `types` alphabetically.
- Set `language` to `string` to be consistent with `countries` even if they're not all supported.
  - `language` really is a "preferred language", so we allow any ISO 639-1 code, even though we only support `en` and `fr` translations for now
- `PKResult` now has `coordinates` (`"lat,lng" string, a bit more conventional), we will deprecate `lat` and `lng` later.