### PR TITLE
Deprecate countryByIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,21 +209,6 @@ pk.reverse({
 
 **Notes:**
 - If you omit `options.coordinates`, it'll use `coordinates` from global parameters set when instanciating with `placekit()` or with `pk.configure()`.
-- If no coordinates are found when calling `pk.reverse()`, then it'll use the user's IP approximate coordinates but relevance will be less accurate.
-- When calling `pk.reverse()`, the API automatically sets `countryByIP` to `true`. Explicitely set it to `false` to turn it off.
-- Calling `pk.reverse()` is the same as calling `pk.search` with an empty query and `countryByIP: true`:
-
-```js
-pk.reverse({
-  countries: ['fr'],
-});
-
-// is the same as:
-pk.search('', {
-  countryByIP: true,
-  countries: ['fr'],
-});
-```
 
 ### `pk.options`
 
@@ -236,12 +221,11 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| [`countries`](#%EF%B8%8F-countries-option-is-required) | `string[]?` | `undefined` | Countries to search in, or fallback to if `countryByIP` is `true`. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes<sup>[(1)](#ft1)</sup>. |
+| [`countries`](#%EF%B8%8F-countries-option-is-required) | `string[]?` | `undefined` | Countries to search in, default to current IP country. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes<sup>[(1)](#ft1)</sup>. |
 | `language` | `string?` | `undefined` | Preferred language for the results<sup>[(1)](#ft1)</sup>, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. By default the results are displayed in their country's language. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
 | `maxResults` | `integer?` | `5` | Number of results per page. |
 | `coordinates` | `string?` | `undefined` | Coordinates to search around. Automatically set when calling [`pk.requestGeolocation()`](#pkrequestGeolocation). |
-| [`countryByIP`](#countryByIP-option) | `boolean?` | `undefined` | Use IP to find user's country (turned off). |
 | `forwardIP` | `string?` | `undefined` | Set `x-forwarded-for` header to forward the provided IP for back-end usages (otherwise it'll use the server IP). |
 
 <a id="ft1"><b>[1]</b></a>: See [Scope and Limitations](https://placekit.io/terms/scope) for more details.
@@ -254,17 +238,6 @@ The `countries` option is **required** at search time, but we like to keep it op
 - or at search time with `pk.search()`.
 
 If `countries` is missing or invalid, you'll get a `422` error, excepted when`types` option is set to `['country']` only.
-
-#### `countryByIP` option
-
-Set `countryByIP` to `true` when you don't know which country users will search locations in. In that case, the option `countries` will be used as a fallback if the user's country is not supported:
-
-```js
-pk.search('123 ave', {
-  countryByIP: true, // use user's country, based on their IP
-  countries: ['fr', 'be'], // returning results from France and Belgium if user's country is not supported
-});
-```
 
 ### `pk.configure()`
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ const placekit = require('@placekit/client-js/lite');
 import placekit from '@placekit/client-js/lite';
 
 const pk = placekit('<your-api-key>', {
-  countries: ['fr'],
   //...
 });
 
@@ -79,7 +78,6 @@ After importing the library, `placekit` becomes available as a global:
 ```html
 <script>
   const pk = placekit('<your-api-key>', {
-    countries: ['fr'],
     //...
   });
 
@@ -221,7 +219,7 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| [`countries`](#%EF%B8%8F-countries-option-is-required) | `string[]?` | `undefined` | Countries to search in, default to current IP country. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes<sup>[(1)](#ft1)</sup>. |
+| `countries` | `string[]?` | `undefined` | Countries to search in, default to current IP country. Array of [two-letter ISO](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country codes<sup>[(1)](#ft1)</sup>. |
 | `language` | `string?` | `undefined` | Preferred language for the results<sup>[(1)](#ft1)</sup>, [two-letter ISO](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code. Supported languages are `en` and `fr`. By default the results are displayed in their country's language. |
 | `types` | `string[]?` | `undefined` | Type of results to show. Array of accepted values: `street`, `city`, `country`, `airport`, `bus`, `train`, `townhall`, `tourism`. Prepend `-` to omit a type like `['-bus']`. Unset to return all. |
 | `maxResults` | `integer?` | `5` | Number of results per page. |
@@ -229,15 +227,6 @@ console.log(pk.options); // { "language": "en", "maxResults": 10, ... }
 | `forwardIP` | `string?` | `undefined` | Set `x-forwarded-for` header to forward the provided IP for back-end usages (otherwise it'll use the server IP). |
 
 <a id="ft1"><b>[1]</b></a>: See [Scope and Limitations](https://placekit.io/terms/scope) for more details.
-
-#### ⚠️ `countries` option is required
-
-The `countries` option is **required** at search time, but we like to keep it optional across all methods so developers remain free on when and how to define it: 
-- either when instanciating with `placekit()`,
-- with `pk.configure()`,
-- or at search time with `pk.search()`.
-
-If `countries` is missing or invalid, you'll get a `422` error, excepted when`types` option is set to `['country']` only.
 
 ### `pk.configure()`
 
@@ -247,7 +236,6 @@ Updates global parameters. Returns `void`.
 pk.configure({
   language: 'fr',
   maxResults: 5,
-  countries: ['fr'],
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/client-js",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/client-js",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-replace": "^5.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/client-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/client-js",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-replace": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/client-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit JavaScript client",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/client-js",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit JavaScript client",
   "license": "MIT",

--- a/src/placekit-lite.d.ts
+++ b/src/placekit-lite.d.ts
@@ -22,7 +22,6 @@ export type PKOptions = {
   language?: string;
   types?: PKTypeFilter[];
   countries?: string[];
-  countryByIP?: boolean;
   forwardIP?: string;
   coordinates?: string;
 };

--- a/src/placekit-lite.test.js
+++ b/src/placekit-lite.test.js
@@ -176,7 +176,6 @@ describe('PlaceKit/Lite: Search', () => {
     const pk = placekit('your-api-key');
     const res = await pk.search('', {
       forwardIP: '0.0.0.0',
-      countryByIP: true,
     });
     const calls = fetchMock.mock.calls;
     assert.equal(calls.length, 1);

--- a/src/placekit.d.ts
+++ b/src/placekit.d.ts
@@ -47,7 +47,6 @@ export type PKOptions = {
   language?: string;
   types?: PKTypeFilter[];
   countries?: string[];
-  countryByIP?: boolean;
   forwardIP?: string;
   coordinates?: string;
 };


### PR DESCRIPTION
`countryByIP` param is deprecated, and `countries` becomes optional. The search now defaults to the country of the sender's IP.
